### PR TITLE
Parse default options to CSV parser based on CSVDDF dialect

### DIFF
--- a/spec/test-pkg/valid-datapackage.json
+++ b/spec/test-pkg/valid-datapackage.json
@@ -21,7 +21,7 @@
         "encoding": "UTF-8",
         "dialect": {
             "delimiter": ",",
-            "lineterminator": "\r\n",
+            "lineterminator": "\n",
             "quotechar": "\"",
             "doublequote": true,
             "skipinitialspace": true


### PR DESCRIPTION
Closes #9 

This follows the letter of the specification, but ideally need to test this against a variety of CSV files. Will do that as part of wider testing.
